### PR TITLE
Puffing - state_dict() method gets hidden by introducing attribute

### DIFF
--- a/puffin.py
+++ b/puffin.py
@@ -66,8 +66,8 @@ class Puffin(nn.Module):
 
         model_path = "./resources/puffin.pth"
 
-        self.state_dict = torch.load(model_path, map_location=torch.device("cpu"))
-        self.load_state_dict(self.state_dict, strict=False)
+        state_dict = torch.load(model_path, map_location=torch.device("cpu"))
+        self.load_state_dict(state_dict, strict=False)
 
     def forward(self, x):
         y = torch.cat([self.conv(x), self.conv(x.flip([1, 2])).flip([2])], 1)


### PR DESCRIPTION
Hey,

first of all, great job with the model & paper :) 

I am playing around with it and noticed that in puffin.py, you are introducing the state_dict attribute in the Puffin class (which is a derivative class of nn.Module). However, because of that, you are hiding state_dict() method - which is widely used for saving the model (e.g., pytorch lightning uses it when it saves checkpoints).

It's a small change, but it will help a lot of people who want to use transfer learning & fine-tune the model.