### PR TITLE
Fixed undefined seq_bp variable error by renaming seq to seq_bp

### DIFF
--- a/puffin.py
+++ b/puffin.py
@@ -689,7 +689,7 @@ if __name__ == "__main__":
                 name = line.strip()[1:]
                 
             else:
-                seq = line.strip()
+                seq_bp = line.strip()
                 
                 if len(seq_bp) < 651:
                     print(


### PR DESCRIPTION
When using the Puffin module with the "sequence" argument, the code throws a "seq_bp" undefined error due to an error in the naming of the variable upstream. It is named "seq" upstream instead of seq_bp and hence the error. I've fixed this by correcting "seq" to "seq_bp". Cheers!